### PR TITLE
Prep for 2.1.0 release - works nicely with Laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "~4",
-        "machuga/authority" : "2.0.*@stable"
+        "machuga/authority" : "2.1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
@@ -42,7 +42,7 @@
     "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "2.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Merge in this PR, then release a new tag for version 2.1.0.  Combined with the PR in machuga/authority, it should make installing things easier for L4.1 users.
